### PR TITLE
ci: add PyPI release workflow with Trusted Publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,73 @@
+name: Release
+
+# Publishes `pcgym` to PyPI via Trusted Publishing on tag push.
+#
+# ONE-TIME SETUP (required before this workflow can publish successfully):
+#   1. On https://pypi.org/manage/account/publishing/ (logged in as a `pcgym`
+#      project owner), add a Trusted Publisher for the existing project:
+#        Owner:         MaximilianB2
+#        Repository:    pc-gym
+#        Workflow:      release.yml
+#        Environment:   release
+#   2. In the GitHub repo settings -> Environments, create an environment
+#      named `release`. Optionally add required reviewers so a maintainer
+#      must approve every publish.
+#   3. (Optional) Repeat for TestPyPI on https://test.pypi.org with the
+#      environment name `release-test` if you want dry-run support.
+#
+# TO CUT A RELEASE:
+#   1. Bump `version` in pyproject.toml.
+#   2. Merge to main.
+#   3. From main: `git tag v0.2.0 && git push origin v0.2.0`
+#   The tag triggers this workflow; `build` runs first, then `publish`
+#   waits for any reviewer approval set on the `release` environment.
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build sdist + wheel
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install build tooling
+        run: |
+          python -m pip install --upgrade pip
+          pip install build twine
+      - name: Build
+        run: python -m build
+      - name: Check metadata
+        run: twine check dist/*
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+          retention-days: 30
+
+  publish:
+    name: Publish to PyPI
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    environment:
+      name: release
+      url: https://pypi.org/project/pcgym/
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - name: Publish via Trusted Publishing
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Triggered by pushing a v* tag. The build job assembles sdist + wheel and validates metadata with twine; the publish job runs only on tag events and uploads via pypa/gh-action-pypi-publish using OIDC Trusted Publishing - no API token in repo secrets.

Publish is bound to a GitHub `release` environment so a maintainer must approve each publish if environment reviewers are configured. The in-file header documents the one-time pypi.org setup needed before the first publish will succeed.

workflow_dispatch is enabled for manual smoke-testing of the build step on any branch; the publish job stays gated on the tag prefix.