### PR TITLE
fix: make model __call__ backend-agnostic under CasADi (#2)

### DIFF
--- a/src/pcgym/model_classes.py
+++ b/src/pcgym/model_classes.py
@@ -104,7 +104,7 @@ class complex_cstr(BaseModel):
         ca, cb, cc, T = x[0], x[1], x[2], x[3]
         xp = jnp if self.int_method == "jax" else np
         if u.shape[0] == 1:
-            Tc = u.reshape(-1)[0]
+            Tc = u[0]
         else:
             Tc, self.Ti, self.Caf = u[0], u[1], u[2]
 
@@ -284,7 +284,7 @@ class invariant_batch(BaseModel):
         self.disturbances = []
 
     def __call__(self, x, u=None):
-        xA, xB, xC, xD = x
+        xA, xB, xC, xD = x[0], x[1], x[2], x[3]
         dxAdt = -(self.k1f * xA * xB - self.k1r * xC) - (self.k2f * xA * xC - self.k2r * xD)
         dxBdt = -(self.k1f * xA * xB - self.k1r * xC)
         dxCdt = (self.k1f * xA * xB - self.k1r * xC) - (self.k2f * xA * xC - self.k2r * xD)
@@ -695,8 +695,8 @@ class cstr_series_recycle:
         Returns:
             np.ndarray: State derivatives
         """
-        C1, T1, C2, T2 = x
-        F, L, Tc1, Tc2 = u
+        C1, T1, C2, T2 = x[0], x[1], x[2], x[3]
+        F, L, Tc1, Tc2 = u[0], u[1], u[2], u[3]
         xp = jnp if self.int_method == "jax" else np
 
         ret = [
@@ -768,8 +768,18 @@ class distillation_column:
         Returns:
             np.ndarray: State derivatives
         """
-        X0, X1, X2, X3, Xf, X4, X5, X6, Xb = x
-        R, F = u
+        X0, X1, X2, X3, Xf, X4, X5, X6, Xb = (
+            x[0],
+            x[1],
+            x[2],
+            x[3],
+            x[4],
+            x[5],
+            x[6],
+            x[7],
+            x[8],
+        )
+        R, F = u[0], u[1]
 
         L = R * self.D
         V = (R + 1) * self.D
@@ -880,8 +890,8 @@ class multistage_extraction_reactive:
             YA5,
             YB5,
             YC5,
-        ) = x
-        L, G = u
+        ) = (x[i] for i in range(20))
+        L, G = u[0], u[1]
 
         XA1_eq = (YA1**self.eq_exponent) / self.m
         XA2_eq = (YA2**self.eq_exponent) / self.m
@@ -1108,8 +1118,8 @@ class heat_exchanger:
             Tt8,
             Tm8,
             Ts8,
-        ) = x
-        Ft, Fs, Tt0, Ts9 = u
+        ) = (x[i] for i in range(24))
+        Ft, Fs, Tt0, Ts9 = u[0], u[1], u[2], u[3]
         xp = jnp if self.int_method == "jax" else np
 
         Vt = self.L * xp.pi * self.Dt**2
@@ -1408,8 +1418,8 @@ class polymerisation_reactor:
         Returns:
             np.ndarray: State derivatives
         """
-        T, M, I = x
-        F, Tf, Mf, If = u
+        T, M, I = x[0], x[1], x[2]
+        F, Tf, Mf, If = u[0], u[1], u[2], u[3]
         xp = jnp if self.int_method == "jax" else np
 
         kp = self.Ap * xp.exp(-self.Ep_over_R / T)

--- a/tests/models/test_casadi_backend.py
+++ b/tests/models/test_casadi_backend.py
@@ -1,0 +1,60 @@
+"""Regression tests ensuring every model is backend-agnostic under CasADi.
+
+The MPC oracle (``oracle.setup_mpc``) evaluates each model with CasADi
+symbolic variables and then ``vertcat``\\ s the returned derivatives. CasADi
+``SX`` objects are *not* iterable, so any model that destructures its state or
+input vector via Python tuple unpacking (``a, b, c = x``) raises
+
+    Exception: CasADi matrices are not iterable by design.
+
+These tests call every model with CasADi symbols of the correct shape -
+mirroring the oracle's evaluation path - to guard against that regression.
+"""
+
+import inspect
+
+import pytest
+from casadi import SX, vertcat
+
+import pcgym.model_classes as mc
+
+
+def _model_classes():
+    """All concrete model classes exposed by ``pcgym.model_classes``."""
+    return {
+        name: obj
+        for name, obj in vars(mc).items()
+        if inspect.isclass(obj) and obj.__module__ == mc.__name__ and name != "BaseModel" and hasattr(obj, "info")
+    }
+
+
+# ``coupled_oscillators`` relies on ``numpy.concatenate`` over symbolic
+# entries, which is a separate (non-tuple-unpacking) CasADi limitation.
+KNOWN_NON_CASADI = {"coupled_oscillators"}
+
+
+@pytest.mark.parametrize("model_name", sorted(_model_classes()))
+def test_model_callable_with_casadi_symbols(model_name):
+    if model_name in KNOWN_NON_CASADI:
+        pytest.xfail(f"{model_name} uses numpy.concatenate over symbolic types (separate CasADi limitation)")
+
+    model = _model_classes()[model_name](int_method="casadi")
+    info = model.info()
+    n_x = len(info["states"])
+    n_u = len(info["inputs"])
+
+    x = SX.sym("x", n_x)
+    if n_u > 0:
+        u = SX.sym("u", n_u)
+        derivatives = model(x, u)
+    else:
+        derivatives = model(x)
+
+    # The oracle vertcats the returned derivatives; this is where a
+    # tuple-unpacked model would already have raised.
+    dx = vertcat(*derivatives)
+    assert dx.shape[0] == n_x, f"{model_name} returned {dx.shape[0]} derivatives for {n_x} states"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
## Summary

Fixes the **CasADi tuple-unpacking** bug (item #2 of the reported batch). Initializing models such as `distillation_column` with the default `casadi` integrator raised:

```
Exception: CasADi matrices are not iterable by design.
```

### Cause
The MPC oracle (`oracle.setup_mpc`) evaluates each model with CasADi `SX` symbols, which are **not iterable**. Models that destructured their state/input vectors with Python tuple unpacking (`a, b, c = x`) worked under NumPy/JAX arrays but blew up under CasADi.

### Fix
Switch the affected models to **explicit indexing** so the equations are backend-agnostic:

- `distillation_column`
- `cstr_series_recycle`
- `multistage_extraction_reactive`
- `heat_exchanger`
- `polymerisation_reactor`
- `invariant_batch`

Also replaced `complex_cstr`'s `u.reshape(-1)[0]` with `u[0]` (CasADi rejects the NumPy-style `reshape(-1)`).

## Tests
Adds `tests/models/test_casadi_backend.py`, which calls **every** model with CasADi symbols of the correct shape — mirroring the oracle's evaluation path — and asserts the derivatives `vertcat` cleanly. Verified all fixed models still produce correct output under the JAX backend too.

```
19 passed, 1 xfailed
```

`coupled_oscillators` is `xfail`ed: it relies on `numpy.concatenate` over symbolic entries, which is a **separate** CasADi limitation (not tuple unpacking) and out of scope here.

## Notes
While investigating the reported batch, I found items **#1 (`int_method` TypeError)** and **#3 (`cstr` `u.shape == (1,)`)** are **already fixed on `main`** — every model is now a `@dataclass(kw_only=True)` with an `int_method` field, and `cstr` already uses `u.shape[0] == 1`. Those were likely reproduced against the older PyPI release (ties into the "PyPI is behind main" report).

🤖 Generated with [Claude Code](https://claude.com/claude-code)