### PR TITLE
feat: override model parameters via env_params["model_params"] (#9)

### DIFF
--- a/src/pcgym/pcgym.py
+++ b/src/pcgym/pcgym.py
@@ -165,15 +165,47 @@ class make_env(gym.Env):
             "hydraulic_tank": hydraulic_tank,
         }
 
+        model_params = self.env_params.get("model_params") or {}
+        if not isinstance(model_params, dict):
+            raise ValueError("model_params must be a dictionary of {parameter_name: value}")
+
         if self.env_params.get("custom_model") is not None:
             m = self.env_params["custom_model"]
             m.int_method = self.integration_method
+            self._apply_model_params(m, model_params)
             self.model = m
         else:
             model_name = self.env_params.get("model")
             if model_name not in model_mapping:
                 raise ValueError(f"Model '{model_name}' not found in model_mapping.")
-            self.model = model_mapping[model_name](int_method=self.integration_method)
+            model_cls = model_mapping[model_name]
+            self._validate_model_params(model_cls, model_params)
+            # Pass overrides to the constructor so any __post_init__ derived
+            # quantities (e.g. state lists sized by a parameter) are rebuilt.
+            self.model = model_cls(int_method=self.integration_method, **model_params)
+
+    @staticmethod
+    def _validate_model_params(model_cls, model_params):
+        """Raise a helpful error if an override is not a parameter of the model."""
+        valid = getattr(model_cls, "__dataclass_fields__", None)
+        if valid is None:
+            return
+        unknown = [k for k in model_params if k not in valid]
+        if unknown:
+            settable = sorted(
+                k for k in valid if k not in ("int_method", "states", "inputs", "disturbances", "uncertainties")
+            )
+            raise ValueError(
+                f"Unknown model_params {unknown} for model '{model_cls.__name__}'. Settable parameters: {settable}"
+            )
+
+    @staticmethod
+    def _apply_model_params(model, model_params):
+        """Override parameters on an already-constructed (custom) model instance."""
+        for name, value in model_params.items():
+            if not hasattr(model, name):
+                raise ValueError(f"Unknown model_params '{name}' for custom model '{type(model).__name__}'")
+            setattr(model, name, value)
 
     def _setup_state_dimensions(self):
         self.Nx = len(self.model.info()["states"])

--- a/tests/environment/test_make_env_model_params.py
+++ b/tests/environment/test_make_env_model_params.py
@@ -1,0 +1,69 @@
+"""Tests for overriding model parameters via ``env_params["model_params"]``."""
+
+import numpy as np
+import pytest
+
+from pcgym import make_env
+
+BASE = {
+    "model": "cstr",
+    "N": 10,
+    "tsim": 10,
+    "integration_method": "casadi",
+    "a_space": {"low": np.array([295.0]), "high": np.array([302.0])},
+    "o_space": {"low": np.array([0.7, 300, 0.8]), "high": np.array([1.0, 350, 0.9])},
+    "SP": {"Ca": [0.85] * 10},
+    "x0": np.array([0.8, 330, 0.8]),
+}
+
+
+def _params(**overrides):
+    params = {k: (v.copy() if isinstance(v, dict) else v) for k, v in BASE.items()}
+    params.update(overrides)
+    return params
+
+
+def test_model_params_override_defaults():
+    default_env = make_env(_params())
+    custom_env = make_env(_params(model_params={"k0": 1.0e10, "V": 120}))
+
+    assert custom_env.model.k0 == 1.0e10
+    assert custom_env.model.V == 120
+    # The default instance is unaffected.
+    assert default_env.model.k0 != 1.0e10
+
+
+def test_model_params_changes_dynamics():
+    """An overridden parameter should actually change the simulated dynamics."""
+    fast = make_env(_params(model_params={"k0": 1.0e11}))
+    slow = make_env(_params(model_params={"k0": 1.0e9}))
+
+    fast.reset()
+    slow.reset()
+    action = np.array([0.0])  # identical (normalised) action for both
+    fast_obs, *_ = fast.step(action)
+    slow_obs, *_ = slow.step(action)
+
+    assert not np.allclose(fast_obs, slow_obs)
+
+
+def test_unknown_model_param_raises():
+    with pytest.raises(ValueError, match="Unknown model_params"):
+        make_env(_params(model_params={"not_a_real_param": 1.0}))
+
+
+def test_model_params_must_be_dict():
+    with pytest.raises(ValueError, match="model_params must be a dictionary"):
+        make_env(_params(model_params=[("k0", 1.0)]))
+
+
+def test_model_params_on_custom_model():
+    """Custom-model instances accept overrides too."""
+    from pcgym.model_classes import cstr
+
+    env = make_env(_params(custom_model=cstr(), model_params={"k0": 5.0e10}))
+    assert env.model.k0 == 5.0e10
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
## Summary

*"Allow the option to set the parameters of the environment instead of changing the parameter envs."*

Previously the only way to change a model's physical parameters (e.g. the CSTR rate constant `k0`) was to edit the model class directly or route through the uncertainty machinery. This PR adds a first-class `model_params` entry in `env_params`:

```python
env_params = {
    "model": "cstr",
    "model_params": {"k0": 1e10, "V": 120},
    ...
}
```

### Behaviour
- **Built-in models:** overrides are passed to the dataclass **constructor**, so any `__post_init__`-derived quantities (e.g. state lists sized by a parameter) are rebuilt correctly.
- **`custom_model` instances:** overrides are applied via `setattr`.
- **Unknown names** raise a clear `ValueError` listing the settable parameters, instead of a cryptic `TypeError`.
- Fully backward compatible — omitting `model_params` behaves exactly as before.

## Tests
`tests/environment/test_make_env_model_params.py`:
- overrides take effect and don't leak across instances
- an overridden parameter actually changes the simulated dynamics
- unknown params / non-dict `model_params` raise helpful errors
- overrides work through the `custom_model` path

```
5 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)