### PR TITLE
feat: default a_space/o_space/x0 fallbacks in make_env (#5)

### DIFF
--- a/src/pcgym/model_defaults.py
+++ b/src/pcgym/model_defaults.py
@@ -1,0 +1,152 @@
+"""Canonical default action/observation spaces and initial states per model.
+
+These let users construct an environment without hand-specifying ``a_space``,
+``o_space`` and ``x0`` every time - which is especially tedious for the larger
+models (the heat exchanger has 24 states, the reactive extraction column 20).
+``make_env`` falls back to these values for any of the three keys the user
+omits from ``env_params``.
+
+The bounds mirror the configurations used for the benchmark suite
+(``scripts/benchmark_models.py``). ``o_space``/``x0`` include the model's
+canonical set-point dimension(s), so they are intended to be used together
+(and with a set point of matching dimensionality).
+"""
+
+import numpy as np
+
+# crystallization initial coefficient of variation / mean length, derived from
+# the leading moment initial conditions.
+_CRYST_CV0 = float(np.sqrt(1800863.24079725 * 1478.00986666666 / (22995.8230590611**2) - 1))
+_CRYST_LN0 = 22995.8230590611 / (1478.00986666666 + 1e-6)
+
+
+def _spaces():
+    """Return the default-spaces table.
+
+    Built lazily so every call yields fresh NumPy arrays and no caller can
+    mutate the shared defaults.
+    """
+    return {
+        "cstr": {
+            "a_space": {"low": np.array([295.0]), "high": np.array([302.0])},
+            "o_space": {"low": np.array([0.7, 300, 0.8]), "high": np.array([1.0, 350, 0.9])},
+            "x0": np.array([0.8, 330, 0.8]),
+        },
+        "first_order_system": {
+            "a_space": {"low": np.array([0.0]), "high": np.array([1.0])},
+            "o_space": {"low": np.array([0.0, 0.0]), "high": np.array([1.0, 1.0])},
+            "x0": np.array([0.1, 0.4]),
+        },
+        "nonsmooth_control": {
+            "a_space": {"low": np.array([-1.0]), "high": np.array([1.0])},
+            "o_space": {"low": np.array([-1.0, -1.0, -1.0]), "high": np.array([1.0, 1.0, 1.0])},
+            "x0": np.array([0.8, 0.0, 0.0]),
+        },
+        "multistage_extraction": {
+            "a_space": {"low": np.array([5.0, 10.0]), "high": np.array([500.0, 1000.0])},
+            "o_space": {"low": np.array([0.0] * 10 + [0.3]), "high": np.array([1.0] * 10 + [0.4])},
+            "x0": np.array([0.55, 0.3, 0.45, 0.25, 0.4, 0.2, 0.35, 0.15, 0.25, 0.1, 0.3]),
+        },
+        "cstr_series_recycle": {
+            "a_space": {
+                "low": np.array([0.001, 0.001, 290.0, 290.0]),
+                "high": np.array([0.01, 0.01, 320.0, 320.0]),
+            },
+            "o_space": {
+                "low": np.array([0.0, 290.0, 0.0, 290.0, 55.0]),
+                "high": np.array([100.0, 400.0, 100.0, 400.0, 85.0]),
+            },
+            "x0": np.array([90.0, 310.0, 85.0, 310.0, 80.0]),
+        },
+        "distillation_column": {
+            "a_space": {"low": np.array([1.0, 80.0]), "high": np.array([10.0, 300.0])},
+            "o_space": {"low": np.array([0.0] * 9 + [0.8]), "high": np.array([1.0] * 9 + [0.95])},
+            "x0": np.array([0.85, 0.75, 0.6, 0.4, 0.2, 0.15, 0.1, 0.05, 0.02, 0.85]),
+        },
+        "multistage_extraction_reactive": {
+            "a_space": {"low": np.array([5.0, 10.0]), "high": np.array([500.0, 1000.0])},
+            "o_space": {"low": np.array([0.0] * 20 + [0.25]), "high": np.array([2.0] * 20 + [0.55])},
+            "x0": np.array([1.0, 0.0, 1.0, 0.0] * 5 + [0.3]),
+        },
+        "four_tank": {
+            "a_space": {"low": np.array([0.1, 0.1]), "high": np.array([10.0, 10.0])},
+            "o_space": {"low": np.array([0.0] * 6), "high": np.array([0.6] * 6)},
+            "x0": np.array([0.141, 0.112, 0.072, 0.42, 0.5, 0.2]),
+        },
+        "photobioreactor": {
+            "a_space": {"low": np.array([100.0, 0.0]), "high": np.array([400.0, 10.0])},
+            "o_space": {
+                "low": np.array([0.0, 0.0, 0.0, 50.0]),
+                "high": np.array([10.0, 1000.0, 300.0, 200.0]),
+            },
+            "x0": np.array([1.0, 150.0, 0.0, 80.0]),
+        },
+        "heat_exchanger": {
+            "a_space": {
+                "low": np.array([0.5, 0.5, 340.0, 300.0]),
+                "high": np.array([5.0, 5.0, 360.0, 320.0]),
+            },
+            "o_space": {"low": np.array([280.0] * 24 + [300.0]), "high": np.array([400.0] * 24 + [360.0])},
+            "x0": np.concatenate([np.tile([350.0, 340.0, 310.0], 8), [340.0]]),
+        },
+        "biofilm_reactor": {
+            "a_space": {
+                "low": np.array([0.0, 1.0, 0.05, 0.05, 0.05]),
+                "high": np.array([10.0, 30.0, 1.0, 1.0, 1.0]),
+            },
+            "o_space": {
+                "low": np.array([0.0, 0.0, 0.0, 0.0] * 4 + [0.9]),
+                "high": np.array([10.0, 10.0, 10.0, 500.0] * 4 + [2.5]),
+            },
+            "x0": np.array([2.0, 0.1, 10.0, 0.1] * 4 + [1.0]),
+        },
+        "polymerisation_reactor": {
+            "a_space": {"low": np.array([0.1, 320.0, 4.0, 0.3]), "high": np.array([2.0, 360.0, 8.0, 1.0])},
+            "o_space": {"low": np.array([300.0, 0.0, 0.0, 1.5]), "high": np.array([400.0, 10.0, 1.0, 3.5])},
+            "x0": np.array([340.0, 5.0, 0.3, 2.0]),
+        },
+        "crystallization": {
+            "a_space": {"low": np.array([10.0]), "high": np.array([40.0])},
+            "o_space": {
+                "low": np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.9, 14.0]),
+                "high": np.array([1e20, 1e20, 1e20, 1e20, 0.5, 2.0, 20.0, 1.1, 16.0]),
+            },
+            "x0": np.array(
+                [
+                    1478.00986666666,
+                    22995.8230590611,
+                    1800863.24079725,
+                    248516167.940593,
+                    0.15861523304,
+                    _CRYST_CV0,
+                    _CRYST_LN0,
+                    1.0,
+                    15.0,
+                ]
+            ),
+        },
+    }
+
+
+def has_defaults(model_name: str) -> bool:
+    """Whether canonical default spaces exist for ``model_name``."""
+    return model_name in _spaces()
+
+
+def get_default(model_name: str, key: str):
+    """Return a fresh copy of the default ``key`` (``a_space``/``o_space``/``x0``).
+
+    Raises:
+        KeyError: if no defaults are registered for ``model_name``.
+        ValueError: if ``key`` is not one of the supported space keys.
+    """
+    table = _spaces()
+    if model_name not in table:
+        raise KeyError(
+            f"No default {key} is registered for model '{model_name}'. "
+            f"Please provide '{key}' explicitly in env_params. "
+            f"Models with defaults: {sorted(table)}"
+        )
+    if key not in table[model_name]:
+        raise ValueError(f"'{key}' is not a defaultable space; expected one of a_space, o_space, x0")
+    return table[model_name][key]

--- a/src/pcgym/pcgym.py
+++ b/src/pcgym/pcgym.py
@@ -26,6 +26,7 @@ from pcgym.model_classes import (
     photo_production,
     polymerisation_reactor,
 )
+from pcgym.model_defaults import get_default, has_defaults
 from pcgym.policy_evaluation import policy_eval
 
 
@@ -42,6 +43,7 @@ class make_env(gym.Env):
             raise ValueError("env_params must be a dictionary")
         self.env_params = copy.deepcopy(env_params)
         self._initialize_action_config()
+        self._apply_space_defaults()
         self._setup_spaces()
         self._configure_reward()
         self._setup_simulation_params()
@@ -60,6 +62,29 @@ class make_env(gym.Env):
             self.a_0 = self.env_params["a_0"]
         self.normalise_a = self.env_params.get("normalise_a", True)
         self.normalise_o = self.env_params.get("normalise_o", True)
+
+    def _apply_space_defaults(self):
+        """Fill in a_space / o_space / x0 from the model's canonical defaults.
+
+        For any of these keys the user omits, fall back to the model's native
+        bounds / initial state (see pcgym.model_defaults) so large models don't
+        need to be fully hand-specified. Custom models have no registered
+        defaults and must supply all three explicitly.
+        """
+        model_name = self.env_params.get("model")
+        is_custom = self.env_params.get("custom_model") is not None
+
+        for key in ("a_space", "o_space", "x0"):
+            if self.env_params.get(key) is not None:
+                continue
+            if is_custom:
+                raise ValueError(f"'{key}' must be provided in env_params when using a custom_model.")
+            if not has_defaults(model_name):
+                raise ValueError(
+                    f"'{key}' is missing from env_params and model '{model_name}' has no registered "
+                    f"defaults. Please specify '{key}' explicitly."
+                )
+            self.env_params[key] = get_default(model_name, key)
 
     def _noise_percentage_setup(self):
         self.noise_percentage = self.env_params.get("noise_percentage")

--- a/tests/environment/test_make_env_defaults.py
+++ b/tests/environment/test_make_env_defaults.py
@@ -1,0 +1,90 @@
+"""Tests for falling back to a model's default a_space / o_space / x0."""
+
+import numpy as np
+import pytest
+
+from pcgym import make_env
+from pcgym.model_classes import cstr
+from pcgym.model_defaults import get_default, has_defaults
+
+
+def test_minimal_config_uses_all_defaults():
+    """A model with registered defaults runs given only model/N/tsim/SP."""
+    env = make_env(
+        {
+            "model": "four_tank",
+            "N": 10,
+            "tsim": 1000,
+            "integration_method": "casadi",
+            "SP": {"h3": [0.5] * 10, "h4": [0.2] * 10},
+        }
+    )
+    obs, _ = env.reset()
+    obs2, _, _, _, _ = env.step(env.action_space.sample())
+
+    # Defaults were injected into env_params.
+    assert np.array_equal(env.env_params["a_space"]["high"], get_default("four_tank", "a_space")["high"])
+    assert np.array_equal(env.env_params["x0"], get_default("four_tank", "x0"))
+    assert obs.shape == obs2.shape
+
+
+def test_partial_override_keeps_user_values():
+    """User-supplied keys are respected; only the omitted ones default."""
+    custom_a = {"low": np.array([0.0, 0.0]), "high": np.array([5.0, 5.0])}
+    env = make_env(
+        {
+            "model": "four_tank",
+            "N": 10,
+            "tsim": 1000,
+            "integration_method": "casadi",
+            "SP": {"h3": [0.5] * 10, "h4": [0.2] * 10},
+            "a_space": custom_a,
+        }
+    )
+    # a_space kept, x0/o_space defaulted.
+    assert np.array_equal(env.env_params["a_space"]["high"], custom_a["high"])
+    assert np.array_equal(env.env_params["x0"], get_default("four_tank", "x0"))
+
+
+def test_custom_model_requires_explicit_spaces():
+    with pytest.raises(ValueError, match="custom_model"):
+        make_env(
+            {
+                "custom_model": cstr(),
+                "N": 10,
+                "tsim": 10,
+                "integration_method": "casadi",
+                "SP": {"Ca": [0.85] * 10},
+            }
+        )
+
+
+def test_model_without_defaults_raises_helpfully():
+    with pytest.raises(ValueError, match="has no registered"):
+        make_env(
+            {
+                "model": "batch",
+                "N": 10,
+                "tsim": 10,
+                "integration_method": "casadi",
+                "reward_states": ["Cc"],
+                "maximise_reward": True,
+            }
+        )
+
+
+def test_defaults_are_fresh_copies():
+    """Mutating a returned default must not corrupt the shared table."""
+    x0_a = get_default("cstr", "x0")
+    x0_a[0] = 999.0
+    x0_b = get_default("cstr", "x0")
+    assert x0_b[0] != 999.0
+
+
+def test_has_defaults():
+    assert has_defaults("distillation_column")
+    assert not has_defaults("batch")
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
## Summary

sensible default spaces so users don't have to hand-specify `a_space`, `o_space` and `x0` for every environment (painful for large models: the heat exchanger has 24 states, the reactive extraction column 20).

Previously, omitting any of these raised a bare `KeyError`. Now:

```python
# Enough to get a working environment:
env = make_env({"model": "distillation_column", "N": 60, "tsim": 20, "SP": {"X0": [0.9]*60}})
```

### Design
- New module `pcgym/model_defaults.py` holds canonical `a_space` / `o_space` / `x0` per model, mirroring the configs in `scripts/benchmark_models.py`.
- `make_env._apply_space_defaults()` fills in **only** the keys the user omits — user-supplied values always win.
- `o_space`/`x0` defaults include the model's canonical set-point dimension(s), so they're meant to be used with a set point of matching dimensionality.
- `custom_model`s and models without registered defaults raise a clear, actionable `ValueError` instead of a `KeyError`.
- Defaults are returned as **fresh copies**, so callers can't corrupt the shared table.

13 models have defaults (every model in the benchmark suite). The handful of exotic models without canonical configs (e.g. `batch`, `coupled_oscillator`) still require explicit spaces and say so.

## Tests
`tests/environment/test_make_env_defaults.py`:
- minimal config (`model`/`N`/`tsim`/`SP`) constructs, resets and steps
- partial override keeps user values, defaults the rest
- custom model / no-defaults models raise helpful errors
- returned defaults are independent copies

```
6 passed
```

## Note
Stacks naturally with #2 (PR #39): the minimal-config path for `distillation_column` and other tuple-unpacking models only runs end-to-end under CasADi once #2 is merged. The tests here use models that already pass on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)